### PR TITLE
Add missing HOVER category to T1 tank

### DIFF
--- a/units/INU1004/INU1004_unit.bp
+++ b/units/INU1004/INU1004_unit.bp
@@ -63,6 +63,7 @@ UnitBlueprint {
         'LAND',
         'TECH1',
         'DIRECTFIRE',
+        'HOVER',
         'VISIBLETORECON',
         'RECLAIMABLE',
         'TANK',


### PR DESCRIPTION
Could fix #366 since my bet is on torpedo weapons not targetting hover units.
Untested.
Should be there either way.