### PR TITLE
Fix  cooldown missing in bombardment ability

### DIFF
--- a/nomadhook/lua/abilitydefinition.lua
+++ b/nomadhook/lua/abilitydefinition.lua
@@ -142,6 +142,7 @@ abilities = table.merged( abilities, {
         ExtraInfo = {
             DoRangeCheck = true,
             NumReticules = 1,
+            CoolDownTime = 30,
         },
         UIHelpText = 'specabil_areabombardment',
         UISlot = 5,


### PR DESCRIPTION
WARNING: Error running lua script: ...programdata\faforever\repo\fa\lua\ai\aibehaviors.lua(3317): attempt to perform arithmetic on field `CoolDownTime' (a nil value)

Error in function CommanderBombardThread()
A cooldown time for the `NomadsAreaBombardment` weapon is missing.

Added `CoolDownTime = 30` to the `NomadsAreaBombardment` ability inside `abilitydefinition.lua`