### PR TITLE
Fix Factory IDs

### DIFF
--- a/loc/US/nomads_faf.lua
+++ b/loc/US/nomads_faf.lua
@@ -9,9 +9,9 @@ xnb0201faf_help = "Constructs Tech 2 land units. HQ factory, required to build s
 xnb0201faf_name = "Land Factory HQ"
 
 -- land factory (support,  specific)
-xnb0211_desc = "Land Factory"
-xnb0211_help = "Constructs Tech 2 land units. Supporting factory, requires a land HQ factory to build same tier land units. Upgradeable once a land HQ factory is built."
-xnb0211_name = "Land Factory"
+znb9501_desc = "Land Factory"
+znb9501_help = "Constructs Tech 2 land units. Supporting factory, requires a land HQ factory to build same tier land units. Upgradeable once a land HQ factory is built."
+znb9501_name = "Land Factory"
 
 -- air factory (HQ,  specific)
 xnb0202faf_desc = "Air Factory HQ"
@@ -19,9 +19,9 @@ xnb0202faf_help = "Constructs Tech 2 air units. HQ factory, required to build sa
 xnb0202faf_name = "Air Factory HQ"
 
 -- air factory (support,  specific)
-xnb0212_desc = "Air Factory"
-xnb0212_help = "Constructs Tech 2 air units. Supporting factory, requires an air HQ factory to build same tier air units. Upgradeable once an air HQ factory is built."
-xnb0212_name = "Air Factory"
+znb9502_desc = "Air Factory"
+znb9502_help = "Constructs Tech 2 air units. Supporting factory, requires an air HQ factory to build same tier air units. Upgradeable once an air HQ factory is built."
+znb9502_name = "Air Factory"
 
 -- naval factory (HQ,  specific)
 xnb0203faf_desc = "Naval Factory HQ"
@@ -29,9 +29,9 @@ xnb0203faf_help = "Constructs Tech 2 naval units. HQ factory, required to build 
 xnb0203faf_name = "Naval Factory HQ"
 
 -- naval factory (support,  specific)
-xnb0213_desc = "Naval Factory"
-xnb0213_help = "Constructs Tech 2 naval units. Supporting factory, requires a naval HQ factory to build same tier naval units. Upgradeable once a naval HQ factory is built."
-xnb0213_name = "Naval Factory"
+znb9503_desc = "Naval Factory"
+znb9503_help = "Constructs Tech 2 naval units. Supporting factory, requires a naval HQ factory to build same tier naval units. Upgradeable once a naval HQ factory is built."
+znb9503_name = "Naval Factory"
 
 -- land factory (HQ,  specific)
 xnb0301faf_desc = "Land Factory HQ"
@@ -39,9 +39,9 @@ xnb0301faf_help = "Constructs Tech 3 land units. HQ factory, required to build s
 xnb0301faf_name = "Land Factory HQ"
 
 -- land factory (support,  specific)
-xnb0311_desc = "Land Factory"
-xnb0311_help = "Constructs Tech 3 land units. Supporting factory, requires a land HQ factory to build same tier land units."
-xnb0311_name = "Land Factory"
+znb9601_desc = "Land Factory"
+znb9601_help = "Constructs Tech 3 land units. Supporting factory, requires a land HQ factory to build same tier land units."
+znb9601_name = "Land Factory"
 
 -- air factory (HQ,  specific)
 xnb0302faf_desc = "Air Factory HQ"
@@ -49,9 +49,9 @@ xnb0302faf_help = "Constructs Tech 3 air units. HQ factory, required to build sa
 xnb0302faf_name = "Air Factory HQ"
 
 -- air factory (support,  specific)
-xnb0312_desc = "Air Factory"
-xnb0312_help = "Constructs Tech 3 air units. Supporting factory, requires an air HQ factory to build same tier units."
-xnb0312_name = "Air Factory"
+znb9602_desc = "Air Factory"
+znb9602_help = "Constructs Tech 3 air units. Supporting factory, requires an air HQ factory to build same tier units."
+znb9602_name = "Air Factory"
 
 -- naval factory (HQ,  specific)
 xnb0303faf_desc = "Naval Factory HQ"
@@ -59,7 +59,7 @@ xnb0303faf_help = "Constructs Tech 3 naval units. HQ factory, required to build 
 xnb0303faf_name = "Naval Factory HQ"
 
 -- naval factory (support,  specific)
-xnb0313_desc = "Naval Factory"
-xnb0313_help = "Constructs Tech 3 naval units. Supporting factory, requires a naval HQ factory to build same tier naval units."
-xnb0313_name = "Naval Factory"
+znb9603_desc = "Naval Factory"
+znb9603_help = "Constructs Tech 3 naval units. Supporting factory, requires a naval HQ factory to build same tier naval units."
+znb9603_name = "Naval Factory"
 

--- a/loc/US/nomads_strings_core.lua
+++ b/loc/US/nomads_strings_core.lua
@@ -572,9 +572,9 @@ xnb0201_help = "Constructs Tech 2 land units. HQ factory, required to build same
 xnb0201_name = "Land Factory HQ"
 
 -- land factory (support, FAF specific)
-xnb0211_desc = "Land Factory"
-xnb0211_help = "Constructs Tech 2 land units. Supporting factory, requires a land HQ factory to build same tier land units. Upgradeable once a land HQ factory is built."
-xnb0211_name = "Land Factory"
+znb9501_desc = "Land Factory"
+znb9501_help = "Constructs Tech 2 land units. Supporting factory, requires a land HQ factory to build same tier land units. Upgradeable once a land HQ factory is built."
+znb9501_name = "Land Factory"
 
 -- air factory (HQ, FAF specific)
 xnb0202_desc = "Air Factory HQ"
@@ -582,9 +582,9 @@ xnb0202_help = "Constructs Tech 2 air units. HQ factory, required to build same 
 xnb0202_name = "Air Factory HQ"
 
 -- air factory (support, FAF specific)
-xnb0212_desc = "Air Factory"
-xnb0212_help = "Constructs Tech 2 air units. Supporting factory, requires an air HQ factory to build same tier air units. Upgradeable once an air HQ factory is built."
-xnb0212_name = "Air Factory"
+znb9502_desc = "Air Factory"
+znb9502_help = "Constructs Tech 2 air units. Supporting factory, requires an air HQ factory to build same tier air units. Upgradeable once an air HQ factory is built."
+znb9502_name = "Air Factory"
 
 -- naval factory (HQ, FAF specific)
 xnb0203_desc = "Naval Factory HQ"
@@ -592,9 +592,9 @@ xnb0203_help = "Constructs Tech 2 naval units. HQ factory, required to build sam
 xnb0203_name = "Naval Factory HQ"
 
 -- naval factory (support, FAF specific)
-xnb0213_desc = "Naval Factory"
-xnb0213_help = "Constructs Tech 2 naval units. Supporting factory, requires a naval HQ factory to build same tier naval units. Upgradeable once a naval HQ factory is built."
-xnb0213_name = "Naval Factory"
+znb9503_desc = "Naval Factory"
+znb9503_help = "Constructs Tech 2 naval units. Supporting factory, requires a naval HQ factory to build same tier naval units. Upgradeable once a naval HQ factory is built."
+znb9503_name = "Naval Factory"
 
 -- Power generator
 xnb1201_desc = "Antimatter-Reactor"
@@ -766,9 +766,9 @@ xnb0301_help = "Constructs Tech 3 land units. HQ factory, required to build same
 xnb0301_name = "Land Factory HQ"
 
 -- land factory (support, FAF specific)
-xnb0311_desc = "Land Factory"
-xnb0311_help = "Constructs Tech 3 land units. Supporting factory, requires a land HQ factory to build same tier land units."
-xnb0311_name = "Land Factory"
+znb9601_desc = "Land Factory"
+znb9601_help = "Constructs Tech 3 land units. Supporting factory, requires a land HQ factory to build same tier land units."
+znb9601_name = "Land Factory"
 
 -- air factory (HQ, FAF specific)
 xnb0302_desc = "Air Factory HQ"
@@ -776,9 +776,9 @@ xnb0302_help = "Constructs Tech 3 air units. HQ factory, required to build same 
 xnb0302_name = "Air Factory HQ"
 
 -- air factory (support, FAF specific)
-xnb0312_desc = "Air Factory"
-xnb0312_help = "Constructs Tech 3 air units. Supporting factory, requires an air HQ factory to build same tier units."
-xnb0312_name = "Air Factory"
+znb9602_desc = "Air Factory"
+znb9602_help = "Constructs Tech 3 air units. Supporting factory, requires an air HQ factory to build same tier units."
+znb9602_name = "Air Factory"
 
 -- naval factory (HQ, FAF specific)
 xnb0303_desc = "Naval Factory HQ"
@@ -786,9 +786,9 @@ xnb0303_help = "Constructs Tech 3 naval units. HQ factory, required to build sam
 xnb0303_name = "Naval Factory HQ"
 
 -- naval factory (support, FAF specific)
-xnb0313_desc = "Naval Factory"
-xnb0313_help = "Constructs Tech 3 naval units. Supporting factory, requires a naval HQ factory to build same tier naval units."
-xnb0313_name = "Naval Factory"
+znb9603_desc = "Naval Factory"
+znb9603_help = "Constructs Tech 3 naval units. Supporting factory, requires a naval HQ factory to build same tier naval units."
+znb9603_name = "Naval Factory"
 
 -- T3 SCU factory
 xnb0304_desc = "SACU Factory"

--- a/nomadhook/lua/keymap/upgradetab.lua
+++ b/nomadhook/lua/keymap/upgradetab.lua
@@ -3,17 +3,18 @@ do
 local nomadupgrades =
 {
     -- nomads
-    ['xnb0101'] = {'xnb0211', 'xnb0201'},
-    ['xnb0102'] = {'xnb0212', 'xnb0202'},
-    ['xnb0103'] = {'xnb0213', 'xnb0203'},
+    ['xnb0101'] = {'xnb0201', 'znb9501'}, -- LAND-1 = LAND-2-HQ , LAND-2-SUP
+    ['xnb0102'] = {'xnb0202', 'znb9502'}, -- AIR-1 = AIR-2-HQ , AIR-2-SUP
+    ['xnb0103'] = {'xnb0203', 'znb9503'}, -- SEA-1 = SEA-2-HQ , SEA-2-SUP
 
-    ['xnb0201'] = 'xnb0301',    -- HQs
-    ['xnb0202'] = 'xnb0302',
-    ['xnb0203'] = 'xnb0303',
+    ['xnb0201'] = 'xnb0301',  -- LAND-2-HQ = LAND-3-HQ
+    ['xnb0202'] = 'xnb0302',  -- AIR-2-HQ = AIR-3-HQ
+    ['xnb0203'] = 'xnb0303',  -- SEA-2-HQ = SEA-3-HQ
 
-    ['xnb0211']  = 'xnb0311',   -- support factories
-    ['xnb0212']  = 'xnb0312',
-    ['xnb0213']  = 'xnb0313',
+    ['znb9501']  = 'znb9601',  -- LAND-2-SUP = LAND-3-SUP
+    ['znb9502']  = 'znb9602',  -- AIR-2-SUP = AIR-3-SUP
+    ['znb9503']  = 'znb9603',  -- SEA-2-SUP = SEA-3-SUP
+
     ['xnb3102']  = 'xnb3202',   -- sonar
     ['xnb3202']  = 'xnb3302',
     ['xnb3101']  = 'xnb3201',   -- radar

--- a/nomadhook/lua/system/Blueprints.lua
+++ b/nomadhook/lua/system/Blueprints.lua
@@ -134,12 +134,12 @@ function GetNewUnitLocations()
     local t = {}
     t = table.cat( t, {
         -- adding all Nomads support factories to the game
-        '/units/xnb0211',
-        '/units/xnb0212',
-        '/units/xnb0213',
-        '/units/xnb0311',
-        '/units/xnb0312',
-        '/units/xnb0313',
+        '/units/znb9501', -- Land Support Tech2
+        '/units/znb9502', -- Air Support Tech2
+        '/units/znb9503', -- Sea Support Tech2
+        '/units/znb9601', -- Land Support Tech3
+        '/units/znb9602', -- Air Support Tech3
+        '/units/znb9603', -- Sea Support Tech3
     })
     return t
 end

--- a/nomadhook/lua/ui/help/unitdescription.lua
+++ b/nomadhook/lua/ui/help/unitdescription.lua
@@ -82,12 +82,12 @@ Description = table.merged( Description, {
     ['xnb0304'] = "<LOC xnb0304_help>Constructs Support command units.",
 
     -- NOMADS SUPPORT FACTORIES (FAF SPECIFIC)
-    ['xnb0211'] = "<LOC xnb0211_help>Constructs Tech 2 land units. Upgradeable.",
-    ['xnb0212'] = "<LOC xnb0212_help>Constructs Tech 2 air units. Upgradeable.",
-    ['xnb0213'] = "<LOC xnb0213_help>Constructs Tech 2 naval units. Upgradeable.",
-    ['xnb0311'] = "<LOC xnb0311_help>Constructs Tech 3 land units. Highest tech level available.",
-    ['xnb0312'] = "<LOC xnb0312_help>Constructs Tech 3 air units. Highest tech level available.",
-    ['xnb0313'] = "<LOC xnb0313_help>Constructs Tech 3 naval units. Highest tech level available.",
+    ['znb9501'] = "<LOC znb9501_help>Constructs Tech 2 land units. Upgradeable.",
+    ['znb9502'] = "<LOC znb9502_help>Constructs Tech 2 air units. Upgradeable.",
+    ['znb9503'] = "<LOC znb9503_help>Constructs Tech 2 naval units. Upgradeable.",
+    ['znb9601'] = "<LOC znb9601_help>Constructs Tech 3 land units. Highest tech level available.",
+    ['znb9602'] = "<LOC znb9602_help>Constructs Tech 3 air units. Highest tech level available.",
+    ['znb9603'] = "<LOC znb9603_help>Constructs Tech 3 naval units. Highest tech level available.",
 
 
     -- WEAPON STRUCTURES


### PR DESCRIPTION
All supportfactories had a wrong UnitId inside AI upgrade template and tooltips.

PR tested with several AI-Uveso games.
(GPG-AI and Sorian AI can't use FAF/Nomads support factories)


