### PR TITLE
Fix BlackHole bone error

### DIFF
--- a/effects/Entities/NBlackhole/NBlackhole_script.lua
+++ b/effects/Entities/NBlackhole/NBlackhole_script.lua
@@ -506,7 +506,9 @@ NBlackhole = Class(NullShell) {
         end
 
         for k, prop in self.PropsBeingSuckedIn do
-
+            if prop:BeenDestroyed() then
+                continue
+            end
             local count = prop:GetBoneCount()
             if count > 1 or not prop.GetPosition then
                 for i = 0, count do


### PR DESCRIPTION
Added a failsafe in case the prop is already destroyed and we can't get the BoneCount

[edit]
WARNING: Error running lua script: ...ds\effects\entities\nblackhole\nblackhole_script.lua(510): Game object has been destroyed
