### PR TITLE
Fix background icons

### DIFF
--- a/units/XNB1102/XNB1102_unit.bp
+++ b/units/XNB1102/XNB1102_unit.bp
@@ -126,7 +126,7 @@ UnitBlueprint {
             RULEUCC_Transport = false,
         },
         FactionName = 'Nomads',
-        Icon = 'land',
+        Icon = 'amph',
         SelectionPriority = 5,
         TechLevel = 'RULEUTL_Basic',
         ToggleCaps = {

--- a/units/XNB1107/XNB1107_unit.bp
+++ b/units/XNB1107/XNB1107_unit.bp
@@ -155,7 +155,7 @@ UnitBlueprint {
             RULEUCC_Transport = false,
         },
         FactionName = 'Nomads',
-        Icon = 'land',
+        Icon = 'amph',
         SelectionPriority = 5,
         TechLevel = 'RULEUTL_Basic',
         UnitName = '<LOC XNB1107_name>Hydrocarbon Power Plant',

--- a/units/XNL0103/XNL0103_unit.bp
+++ b/units/XNL0103/XNL0103_unit.bp
@@ -152,6 +152,7 @@ UnitBlueprint {
             RULEUCC_Stop = true,
             RULEUCC_Transport = false,
         },
+        Icon = 'land',
         FactionName = 'Nomads',
         OrderOverrides = {
             RULEUTC_SpecialToggle = {


### PR DESCRIPTION
Mass Extractor and Hydrocarbon Power Plant are amphibic buildings,
and Mobile Anti-Air Gun was missing the icon.