### PR TITLE
Fix SelectionPriority

### DIFF
--- a/units/XNA0401/XNA0401_unit.bp
+++ b/units/XNA0401/XNA0401_unit.bp
@@ -261,6 +261,7 @@ UnitBlueprint {
         },
         FactionName = 'Nomads',
         Icon = 'air',
+        SelectionPriority = 2,
         TechLevel = 'RULEUTL_Secret',
         UnitName = '<LOC XNA0401_name>Comet',
         UnitWeight = 1,

--- a/units/XNL0209/XNL0209_unit.bp
+++ b/units/XNL0209/XNL0209_unit.bp
@@ -297,7 +297,7 @@ UnitBlueprint {
                 helpText = 'toggle_radar_boost',
             },
         },
-        SelectionPriority = 2,
+        SelectionPriority = 3,
         TechLevel = 'RULEUTL_Advanced',
         ToggleCaps = {
             RULEUTC_IntelToggle = true,


### PR DESCRIPTION
Unit xnl0209 (Field Engineer) Changed General.SelectionPriority from "2" to 3
Unit xna0401 (Experimental Transport) Changed General.SelectionPriority from "1" to 2

Info:
SelectionPriority 1 =
Categories.MOBILE or Categories.CRABEGG

SelectionPriority 2 =
Categories.TRANSPORTATION and Categories.TRANSPORTFOCUS

SelectionPriority 3 =
Categories.ENGINEER and Categories.CONSTRUCTION and not Categories.STATIONASSISTPOD

SelectionPriority 5 =
Categories.STRUCTURE and not Categories.CRABEGG then

SelectionPriority 6 =
Categories.POD