### PR TITLE
Fix veteran mass multi for experimentals

### DIFF
--- a/units/XNA0401/XNA0401_unit.bp
+++ b/units/XNA0401/XNA0401_unit.bp
@@ -325,6 +325,7 @@ UnitBlueprint {
         DontUseForcedAttachPoints = true,
         TransportClass = 10,
     },
+    VeteranMassMult = 0.5,
     Weapon = {
         {
             Audio = {

--- a/units/XNL0401/XNL0401_unit.bp
+++ b/units/XNL0401/XNL0401_unit.bp
@@ -363,6 +363,7 @@ UnitBlueprint {
         Level4 = 320,
         Level5 = 400,
     },
+    VeteranMassMult = 0.5,
     Weapon = {
         {
             AboveWaterTargetsOnly = true,

--- a/units/XNL0402/XNL0402_unit.bp
+++ b/units/XNL0402/XNL0402_unit.bp
@@ -219,6 +219,7 @@ UnitBlueprint {
         Level4 = 120,
         Level5 = 150,
     },
+    VeteranMassMult = 0.5,
     Weapon = {
         {
             AboveWaterFireOnly = true,

--- a/units/XNL0403/XNL0403_unit.bp
+++ b/units/XNL0403/XNL0403_unit.bp
@@ -396,6 +396,7 @@ UnitBlueprint {
         Level4 = 200,
         Level5 = 250,
     },
+    VeteranMassMult = 0.5,
     Weapon = {
         {
             Audio = {


### PR DESCRIPTION
FAF is using a massmultiplier to calculate the veteran level for experimentals.
Need to be added to all experimentals that can be killed.