### PR TITLE
Fix Depricated function in unit XNL0301

### DIFF
--- a/units/XNL0301/XNL0301_script.lua
+++ b/units/XNL0301/XNL0301_script.lua
@@ -327,13 +327,13 @@ XNL0301 = Class(NWalkingLandUnit) {
     OnPaused = function(self)
         NWalkingLandUnit.OnPaused(self)
         if self.BuildingUnit then
-            NWalkingLandUnit.StopBuildingEffects(self, self:GetUnitBeingBuilt())
+            NWalkingLandUnit.StopBuildingEffects(self, self.UnitBeingBuilt)
         end
     end,
 
     OnUnpaused = function(self)
         if self.BuildingUnit then
-            NWalkingLandUnit.StartBuildingEffects(self, self:GetUnitBeingBuilt(), self.UnitBuildOrder)
+            NWalkingLandUnit.StartBuildingEffects(self, self.UnitBeingBuilt, self.UnitBuildOrder)
         end
         NWalkingLandUnit.OnUnpaused(self)
     end,


### PR DESCRIPTION
Unit XNL0301 is using the depricated function GetUnitBeingBuilt()
Changed it to .UnitBeingBuilt