### PR TITLE
Removing buildplatoon for non existing unit

### DIFF
--- a/lua/CustomFactions/NomadsAIFiles/BuildingTemplates.lua
+++ b/lua/CustomFactions/NomadsAIFiles/BuildingTemplates.lua
@@ -226,10 +226,10 @@ BuildingTemplates = {
             'T4LandExperimental1',
             'xnl0402',
         },
-        {
-            'T4LandExperimental2',
-            'xnl0401',
-        },
+--        {
+--            'T4LandExperimental2',
+--            'xnl0401',
+--        },
         {
             'T4AirExperimental1',
             'xna0401',


### PR DESCRIPTION
Unit xnl0401 can't be build from the AI.
(no techevel)
Removed the template from the BuildingTemplate table
(only outcommented, i guess we will need it later again)