### PR TITLE
Fix RackSalvoReloadState after dead (XNS0205 )

### DIFF
--- a/units/XNS0205/XNS0205_script.lua
+++ b/units/XNS0205/XNS0205_script.lua
@@ -44,6 +44,10 @@ XNS0205 = Class(NSeaUnit) {
                         --WARN("reloading")
                         WaitSeconds(1.2)
                         --WARN('wait time elapsed')
+                        if not self or self:BeenDestroyed() then
+                            --WARN('Nomads: Unit XNS0205: RackSalvoReloadState: Unit died while reloading Weapon Rack. ')
+                            return
+                        end
                         HVFlakWeapon.RackSalvoReloadState.Main(self)
                         self.unit:OnTargetLost()
                     end)


### PR DESCRIPTION
The RackSalvoReloadState function has a waittime and can wait longer than the unit exist.
Fixed by `if BeenDestroyed then` ...