### PR TITLE
Small Typographical Errors

### DIFF
--- a/loc/US/nomads_strings_core.lua
+++ b/loc/US/nomads_strings_core.lua
@@ -599,7 +599,7 @@ znb9503_name = "Naval Factory"
 -- Power generator
 xnb1201_desc = "Power Generator"
 xnb1201_help = "Mid-level power generator. Construct next to other structures for adjacency bonus. Explodes violently when destroyed, this can cause chain reactions."
-xnb1201_name = "Antimatter-Reactor"
+xnb1201_name = "Antimatter Reactor"
 
 -- mass extractor
 xnb1202_desc = "Mass Extractor"

--- a/loc/US/nomads_strings_core.lua
+++ b/loc/US/nomads_strings_core.lua
@@ -597,7 +597,7 @@ znb9503_help = "Constructs Tech 2 naval units. Supporting factory, requires a na
 znb9503_name = "Naval Factory"
 
 -- Power generator
-xnb1201_desc = "Antimatter-Reactor"
+xnb1201_desc = "Power Generator"
 xnb1201_help = "Mid-level power generator. Construct next to other structures for adjacency bonus. Explodes violently when destroyed, this can cause chain reactions."
 xnb1201_name = "Antimatter-Reactor"
 

--- a/units/XNB1201/XNB1201_unit.bp
+++ b/units/XNB1201/XNB1201_unit.bp
@@ -240,7 +240,7 @@ UnitBlueprint {
         Icon = 'land',
         SelectionPriority = 5,
         TechLevel = 'RULEUTL_Advanced',
-        UnitName = '<LOC XNB1201_name>Antimatter-Reactor',
+        UnitName = '<LOC XNB1201_name>Antimatter Reactor',
         UnitWeight = 1,
     },
     Intel = {

--- a/units/XNB1201/XNB1201_unit.bp
+++ b/units/XNB1201/XNB1201_unit.bp
@@ -57,7 +57,7 @@ UnitBlueprint {
         SubThreatLevel = 0,
         SurfaceThreatLevel = 0,
     },
-    Description = '<LOC XNB1201_desc>Antimatter-Reactor',
+    Description = '<LOC XNB1201_desc>Power Generator',
     Display = {
         Abilities = {
             '<LOC ability_deathaoe>Volatile',


### PR DESCRIPTION
Self Explanatory. This will fix the issue of the T2 Antimatter Reactor being labelled in game as:

Antimatter-Reactor: Tech 2 Antimatter-Reactor

Which is not in line with all other Power Generators. In addition, I removed the hyphen, to standardize with the Tech 3 Nomads Power Generator. 