### PR TITLE
T1 Tank Script Cleanup (Removing Hover)

### DIFF
--- a/units/XNL0201/XNL0201_Script.lua
+++ b/units/XNL0201/XNL0201_Script.lua
@@ -1,10 +1,9 @@
 -- T1 tank
 
-local NHoverLandUnit = import('/lua/nomadsunits.lua').NHoverLandUnit
+local NLandUnit = import('/lua/nomadsunits.lua').NLandUnit
 local ParticleBlaster1 = import('/lua/nomadsweapons.lua').ParticleBlaster1
-local SlowHover = import('/lua/defaultunits.lua').SlowHoverLandUnit
 
-XNL0201 = Class(NHoverLandUnit, SlowHover) {
+XNL0201 = Class(NLandUnit) {
     Weapons = {
         MainGun = Class(ParticleBlaster1) {},
     },


### PR DESCRIPTION
This commit removes the Hover code from the T1 Tank, the 'Orbis'.

This code is no longer necessary, as the Orbis is no longer a hover
vehicle.