### PR TITLE
Apply new values to radar toggle mechanic

### DIFF
--- a/units/XNB3101/XNB3101_unit.bp
+++ b/units/XNB3101/XNB3101_unit.bp
@@ -162,8 +162,8 @@ UnitBlueprint {
         BuildableCategory = {
             'xnb3201',
         },
-        MaintenanceConsumptionPerSecondEnergy = 20,
-        MaintenanceConsumptionPerSecondEnergyBoosted = 50,
+        MaintenanceConsumptionPerSecondEnergy = 5,
+        MaintenanceConsumptionPerSecondEnergyBoosted = 20,
         RebuildBonusIds = {
             'xnb3101',
         },
@@ -213,8 +213,8 @@ UnitBlueprint {
         UpgradesTo = 'xnb3201',
     },
     Intel = {
-        RadarRadius = 115,
-        RadarRadiusBoosted = 175,
+        RadarRadius = 80,
+        RadarRadiusBoosted = 115,
         ShowIntelOnSelect = true,
         VisionRadius = 20,
     },

--- a/units/XNB3102/XNB3102_unit.bp
+++ b/units/XNB3102/XNB3102_unit.bp
@@ -109,8 +109,8 @@ UnitBlueprint {
         BuildableCategory = {
             'xnb3202',
         },
-        MaintenanceConsumptionPerSecondEnergy = 10,
-        MaintenanceConsumptionPerSecondEnergyBoosted = 50,
+        MaintenanceConsumptionPerSecondEnergy = 5,
+        MaintenanceConsumptionPerSecondEnergyBoosted = 20,
         RebuildBonusIds = {
             'xnb3102',
         },
@@ -160,8 +160,8 @@ UnitBlueprint {
     },
     Intel = {
         ShowIntelOnSelect = true,
-        SonarRadius = 115,
-        SonarRadiusBoosted = 175,
+        SonarRadius = 80,
+        SonarRadiusBoosted = 115,
         VisionRadius = 20,
     },
     Interface = {

--- a/units/XNB3201/XNB3201_unit.bp
+++ b/units/XNB3201/XNB3201_unit.bp
@@ -150,7 +150,7 @@ UnitBlueprint {
             'xnb3301',
         },
         MaintenanceConsumptionPerSecondEnergy = 150,
-        MaintenanceConsumptionPerSecondEnergyBoosted = 300,
+        MaintenanceConsumptionPerSecondEnergyBoosted = 600,
         RebuildBonusIds = {
             'xnb3201',
         },

--- a/units/XNB3202/XNB3202_unit.bp
+++ b/units/XNB3202/XNB3202_unit.bp
@@ -112,8 +112,8 @@ UnitBlueprint {
         BuildableCategory = {
             'xnb3302',
         },
-        MaintenanceConsumptionPerSecondEnergy = 100,
-        MaintenanceConsumptionPerSecondEnergyBoosted = 250,
+        MaintenanceConsumptionPerSecondEnergy = 50,
+        MaintenanceConsumptionPerSecondEnergyBoosted = 200,
         RebuildBonusIds = {
             'xnb3202',
         },
@@ -165,7 +165,7 @@ UnitBlueprint {
     Intel = {
         ShowIntelOnSelect = true,
         SonarRadius = 230,
-        SonarRadiusBoosted = 280,
+        SonarRadiusBoosted = 345,
         VisionRadius = 25,
     },
     Interface = {

--- a/units/XNB3202/XNB3202_unit.bp
+++ b/units/XNB3202/XNB3202_unit.bp
@@ -112,8 +112,8 @@ UnitBlueprint {
         BuildableCategory = {
             'xnb3302',
         },
-        MaintenanceConsumptionPerSecondEnergy = 50,
-        MaintenanceConsumptionPerSecondEnergyBoosted = 200,
+        MaintenanceConsumptionPerSecondEnergy = 100,
+        MaintenanceConsumptionPerSecondEnergyBoosted = 400,
         RebuildBonusIds = {
             'xnb3202',
         },

--- a/units/XNB3301/XNB3301_unit.bp
+++ b/units/XNB3301/XNB3301_unit.bp
@@ -138,7 +138,7 @@ UnitBlueprint {
         BuildCostMass = 2400,
         BuildTime = 2575,
         MaintenanceConsumptionPerSecondEnergy = 2000,
-        MaintenanceConsumptionPerSecondEnergyBoosted = 4000,
+        MaintenanceConsumptionPerSecondEnergyBoosted = 8000,
         RebuildBonusIds = {
             'xnb3301',
         },
@@ -191,7 +191,7 @@ UnitBlueprint {
         OmniRadius = 200,
         OmniRadiusBoosted = 300,
         RadarRadius = 600,
-        RadarRadiusBoosted = 800,
+        RadarRadiusBoosted = 900,
         ShowIntelOnSelect = true,
         VisionRadius = 30,
     },

--- a/units/XNB3302/XNB3302_unit.bp
+++ b/units/XNB3302/XNB3302_unit.bp
@@ -143,7 +143,7 @@ UnitBlueprint {
         BuildCostMass = 1000,
         BuildTime = 750,
         MaintenanceConsumptionPerSecondEnergy = 250,
-        MaintenanceConsumptionPerSecondEnergyBoosted = 500,
+        MaintenanceConsumptionPerSecondEnergyBoosted = 1000,
         RebuildBonusIds = {
             'xnb3302',
         },


### PR DESCRIPTION
Overall toggle gives you +50% efficiency for x4 power drain.

Radar values:
80 > 115 |>| 200 > 300 |>| 600 > 800 radar
for
-5 > -20|>|-150 > -600 |>| -2k > -8k power

Sonar:
80 > 115 |>| 230 > 345 |>| 450 > 600 sonar
for:
-5 > -20 |>| -100 > -400 |>| -250 > -1k power