### PR TITLE
Adjust T1 bomber price and firing patterns to match FAF balance

### DIFF
--- a/units/XNA0103/XNA0103_unit.bp
+++ b/units/XNA0103/XNA0103_unit.bp
@@ -193,8 +193,8 @@ UnitBlueprint {
         UniformScale = 0.093-- from 0.125,
     },
     Economy = {
-        BuildCostEnergy = 2400,
-        BuildCostMass = 120,
+        BuildCostEnergy = 2450,
+        BuildCostMass = 105,
         BuildTime = 700,
     },
     Footprint = {
@@ -330,7 +330,7 @@ UnitBlueprint {
             RackSalvoSize = 5,
             RackSlavedToTurret = false,
             RangeCategory = 'UWRC_DirectFire',
-            RateOfFire = 0.25,
+            RateOfFire = 0.2,
             TargetCheckInterval = 1,
             TargetPriorities = {
                 'SPECIALHIGHPRI',


### PR DESCRIPTION
It follow some old pattern, now it cost same and have same rof as other
bombers.