### PR TITLE
Fix Shield rotato animation on pause and unpause

### DIFF
--- a/lua/nomadsunits.lua
+++ b/lua/nomadsunits.lua
@@ -936,26 +936,30 @@ NShieldStructureUnit = Class(ShieldStructureUnit) {
 
     OnStopBeingBuilt = function(self, builder, layer)
         ShieldStructureUnit.OnStopBeingBuilt(self,builder,layer)
-
         local bone = self:GetBlueprint().Display.ShieldOnRotatingBone
         if bone then
             self.RotatorManip = CreateRotator(self, bone, 'y', nil, nil, 2, self.RotationSpeed)
             self.Trash:Add(self.RotatorManip)
         end
         if self.RotatorManip and builder and EntityCategoryContains(categories.SHIELD, builder) then
-            local speed = builder.RotationSpeed or self.RotationSpeed
-            self.RotatorManip:SetSpeed(speed)
+            self.RotatorManip:SetSpeed(self.RotationSpeed)
             self.RotatorManip:SetCurrentAngle(builder.RotatorManip:GetCurrentAngle())
         end
     end,
 
     OnShieldEnabled = function(self)
         ShieldStructureUnit.OnShieldEnabled(self)
+        if self.RotatorManip then
+            self.RotatorManip:SetTargetSpeed(self.RotationSpeed)
+        end
         self:PlayUnitAmbientSound('ShieldActiveLoop')
     end,
 
     OnShieldDisabled = function(self)
         ShieldStructureUnit.OnShieldDisabled(self)
+        if self.RotatorManip then
+            self.RotatorManip:SetTargetSpeed(0)
+        end
         self:StopUnitAmbientSound('ShieldActiveLoop')
     end,
 

--- a/units/XNB4202/XNB4202_script.lua
+++ b/units/XNB4202/XNB4202_script.lua
@@ -13,6 +13,7 @@ XNB4202 = Class(NShieldStructureUnit) {
     end,
 
     OnShieldEnabled = function(self)
+        NShieldStructureUnit.OnShieldEnabled(self)
         if self.ShieldEffectsBag then
             for k, v in self.ShieldEffectsBag do
                 v:Destroy()

--- a/units/XNB4205/XNB4205_script.lua
+++ b/units/XNB4205/XNB4205_script.lua
@@ -28,6 +28,7 @@ XNB4205 = Class(NShieldStructureUnit) {
     end,
 
     OnShieldEnabled = function(self)
+        NShieldStructureUnit.OnShieldEnabled(self)
         if self.ShieldEffectsBag then
             for k, v in self.ShieldEffectsBag do
                 v:Destroy()

--- a/units/XNB4301/XNB4301_script.lua
+++ b/units/XNB4301/XNB4301_script.lua
@@ -18,6 +18,7 @@ XNB4301 = Class(NShieldStructureUnit) {
     end,
 
     OnShieldEnabled = function(self)
+        NShieldStructureUnit.OnShieldEnabled(self)
         if self.ShieldEffectsBag then
             for k, v in self.ShieldEffectsBag do
                 v:Destroy()

--- a/units/XNB4305/XNB4305_script.lua
+++ b/units/XNB4305/XNB4305_script.lua
@@ -29,6 +29,7 @@ XNB4305 = Class(NShieldStructureUnit) {
 
 
     OnShieldEnabled = function(self)
+        NShieldStructureUnit.OnShieldEnabled(self)
         if self.ShieldEffectsBag then
             for k, v in self.ShieldEffectsBag do
                 v:Destroy()


### PR DESCRIPTION
Shield rotator animation will now stop on pause and resume on unpause.

Changed units: Tech 2+3 shield and stealth field

Also fixed `local speed = builder.RotationSpeed or self.RotationSpeed`

`builder.RotationSpeed` is only the shield.RotationSpeed if upgraded to stealth field generator and has the same (hardcoded) animation speed than the stealth field.

So we can use `self.RotationSpeed` in any cases.