### PR TITLE
Use saved EntityId from the unit

### DIFF
--- a/nomadhook/lua/AI/AIBehaviors.lua
+++ b/nomadhook/lua/AI/AIBehaviors.lua
@@ -348,7 +348,7 @@ function OrbitalBombardmentThread(cdr, platoon)
                         end
 
                         -- dont persist attacking, if we didnt kill it in the previous 3 times we probably wont the next time either.
-                        if table.count( LastTargets, targetUnit:GetEntityId() ) >= 3 then
+                        if table.count( LastTargets, targetUnit.EntityId ) >= 3 then
                             continue
                         end
 
@@ -364,7 +364,7 @@ function OrbitalBombardmentThread(cdr, platoon)
                             continue
                         end
 
-                        target = GetUnitById( targetUnit:GetEntityId() )
+                        target = GetUnitById( targetUnit.EntityId )
                         break
                     end
 
@@ -391,7 +391,7 @@ function OrbitalBombardmentThread(cdr, platoon)
                     end
 
                     -- dont persist attacking, if we didnt kill it in the previous 3 times we probably wont the next time either.
-                    if table.count( LastTargets, targetUnit:GetEntityId() ) >= 3 then
+                    if table.count( LastTargets, targetUnit.EntityId ) >= 3 then
                         continue
                     end
 
@@ -409,7 +409,7 @@ function OrbitalBombardmentThread(cdr, platoon)
                         continue
                     end
 
-                    target = GetUnitById( targetUnit:GetEntityId() )
+                    target = GetUnitById( targetUnit.EntityId )
                     break
                 end
 
@@ -426,7 +426,7 @@ function OrbitalBombardmentThread(cdr, platoon)
 
         if target then
 
-            LastTargets[ LastTargetsCounter ] = target:GetEntityId()
+            LastTargets[ LastTargetsCounter ] = target.EntityId
             LastTargetsCounter = LastTargetsCounter + 1
             if LastTargetsCounter > 10 then
                LastTargetsCounter = 1
@@ -453,7 +453,7 @@ function OrbitalBombardmentThread(cdr, platoon)
                         end
                     end
                     if UnitAdjNum > BestUnitAdjNum then
-                        BestUnit = GetUnitById( targetUnit:GetEntityId() )
+                        BestUnit = GetUnitById( targetUnit.EntityId )
                         BestUnitAdjNum = UnitAdjNum
                     end
                 end
@@ -473,7 +473,7 @@ function OrbitalBombardmentThread(cdr, platoon)
             end
 
             -- prepare script command
-            local UnitId = brain.NomadsMothership:GetEntityId()
+            local UnitId = brain.NomadsMothership.EntityId
             local ExtraInfo = AbilityDef.ExtraInfo
             local angle = RandomFloat(0, math.pi)
             if DoSpreadAttack then

--- a/nomadhook/lua/SimSync.lua
+++ b/nomadhook/lua/SimSync.lua
@@ -44,7 +44,7 @@ function AddVOUnitEvent(unit, event)
     if unit and event then
         local army = unit:GetArmy()
         if army ~= nil then
-            table.insert(Sync.VOUnitEvents, { Army = army, UnitId = unit:GetEntityId(), Event = event })
+            table.insert(Sync.VOUnitEvents, { Army = army, UnitId = unit.EntityId, Event = event })
         end
     end
 end

--- a/nomadhook/lua/aibrain.lua
+++ b/nomadhook/lua/aibrain.lua
@@ -72,7 +72,7 @@ AIBrain = Class(oldAIBrain) {
     --units update themselves in the list when they gain, change or lose abilities
     --brain:SetUnitSpecialAbility(self, 'OrbitalBombardment', {AvailableNowUnit = 1,})
     SetUnitSpecialAbility = function(self, unit, abilityName, data)
-        local unitId = unit:GetEntityId()
+        local unitId = unit.EntityId
         --replace unit argument with unitId argument?
         if data == 'Remove' then
             if self.UnitSpecialAbilities[unitId][abilityName] then

--- a/nomadhook/lua/sim/Buff.lua
+++ b/nomadhook/lua/sim/Buff.lua
@@ -96,7 +96,7 @@ function BuffAffectUnit(unit, buffName, instigator, afterRemove)
 
                 wep:ChangeMaxRadius(val)
 
-                --LOG('*BUFF: Unit ', repr(unit:GetEntityId()), ' buffed max radius to ', repr(val))
+                --LOG('*BUFF: Unit ', repr(unit.EntityId), ' buffed max radius to ', repr(val))
             end
 
         elseif atype == 'RateOfFire'

--- a/nomadhook/lua/sim/ScriptTask.lua
+++ b/nomadhook/lua/sim/ScriptTask.lua
@@ -31,7 +31,7 @@ ScriptTask = Class(oldScriptTask) {
             self.TargetLocations = {}
             self.Targets = {}
             local unit = self:GetUnit()
-            local unitId = unit:GetEntityId()
+            local unitId = unit.EntityId
 
             for _, data in commandData.ExtraInfo.Targets do
                 if data.UnitId == unitId then

--- a/units/XNO0001/XNO0001_script.lua
+++ b/units/XNO0001/XNO0001_script.lua
@@ -103,8 +103,8 @@ xno0001 = Class(NOrbitUnit, NCommandFrigateUnit) {
         -- puts on the build queue to create a unit of the given type. If a callback is passed it will be run when the unit is
         -- constructed.
         if unitType and type(unitType) == 'string' then
-            if parentUnit and parentUnit:GetEntityId() then
-                self.OrbitalSpawnQueue[parentUnit:GetEntityId()] = { unitType = unitType, parentUnit = parentUnit or false, attachBone = attachBone or 0, }
+            if parentUnit and parentUnit.EntityId then
+                self.OrbitalSpawnQueue[parentUnit.EntityId] = { unitType = unitType, parentUnit = parentUnit or false, attachBone = attachBone or 0, }
             else
                 WARN('Nomads: parent unit is missing or misformated when requesting orbital spawn! Attempting to spawn unit without parent.')
                 --normally the entity ID is unique. with no parent, we create a unique identifier for this table


### PR DESCRIPTION
EntityId is saved in the unit on creation, so this is faster than
calling an engine function. Works only in sim on unit entities.

From https://github.com/FAForever/fa/pull/2941