### PR TITLE
Tactical Missile Launcher Projectile

### DIFF
--- a/projectiles/NTacticalMissile1/NTacticalMissile1_Script.lua
+++ b/projectiles/NTacticalMissile1/NTacticalMissile1_Script.lua
@@ -29,7 +29,7 @@ NTacticalMissile1 = Class(NIFCruiseMissile) {
     SetTurnRateByDist = function(self)
         local dist = self:GetDistanceToTarget() --defined in NIFCruiseMissile class
         if dist > 50 then
-            self:SetTurnRate(25)
+            self:SetTurnRate(9)
         elseif dist > 40 and dist <= 213 then
             self:SetTurnRate(20)
             WaitSeconds(0.5)


### PR DESCRIPTION
i updated the NTacticalMissile1 to use a lower Turnrate in the First SetTurnRateByDist Distance Check

i excluded the Changes to the BP that added a slight RotationalVelocity to the Projectile since the "Airbrakes" at the Rear on the Projectile would most likely induce a Rotation to some Degree