### PR TITLE
Nerf Mauler

### DIFF
--- a/units/XNL0304/XNL0304_Script.lua
+++ b/units/XNL0304/XNL0304_Script.lua
@@ -7,11 +7,31 @@ local EffectUtil = import('/lua/EffectUtilities.lua')
 
 XNL0304 = Class(NLandUnit) {
     Weapons = {
-		ArtilleryGun = Class(ArtilleryWeapon) {},
+        ArtilleryGun = Class(ArtilleryWeapon) {
+            SetMovingAccuracy = function(self, bool)
+                local bp = self:GetBlueprint()
+                if bool then
+                    self:SetFiringRandomness( bp.FiringRandomnessWhileMoving or (math.max(0, bp.FiringRandomness) * 4) )
+                else
+                    self:SetFiringRandomness( bp.FiringRandomness )
+                end
+            end,
+        },
     },
-	
-	OnCreate = function(self)
+    
+    OnCreate = function(self)
         NLandUnit.OnCreate(self)
+    end,
+        
+    OnMotionHorzEventChange = function( self, new, old )
+        NLandUnit.OnMotionHorzEventChange( self, new, old )
+        self:UpdateWeaponAccuracy( (new ~= 'Stopped' and new ~= 'Stopping') )
+    end,
+
+    UpdateWeaponAccuracy = function(self, moving)
+        if not self.Dead then
+            self:GetWeapon(1):SetMovingAccuracy(moving)
+        end
     end,
 }
 

--- a/units/XNL0304/XNL0304_unit.bp
+++ b/units/XNL0304/XNL0304_unit.bp
@@ -228,7 +228,7 @@ UnitBlueprint {
             },
             BallisticArc = 'RULEUBA_HighArc',
             CollideFriendly = false,
-            Damage = 600,
+            Damage = 1200,
             DamageFriendly = true,
             DamageRadius = 3,
             DamageType = 'Normal',
@@ -236,7 +236,8 @@ UnitBlueprint {
             FireTargetLayerCapsTable = {
                 Land = 'Land|Water|Seabed',
             },
-            FiringRandomness = 1.5,
+            FiringRandomness = 1,
+            FiringRandomnessWhileMoving = 2,
             FiringTolerance = 2,
             IgnoreIfDisabled = true,
             Label = 'ArtilleryGun',
@@ -267,7 +268,7 @@ UnitBlueprint {
             RackSalvoSize = 1,
             RackSlavedToTurret = false,
             RangeCategory = 'UWRC_IndirectFire',
-            RateOfFire = 0.133,
+            RateOfFire = 0.067,
             RenderFireClock = true,
             TargetCheckInterval = 1,
             TargetPriorities = {


### PR DESCRIPTION
Remove meta of arty spam for nomads. This change doubles damage per
shot, but also doubles reload time (15 sec now).
Arty is more accurate when stationary, but much less accurate while
moving.