### PR TITLE
Make Crawler missiles gain height

### DIFF
--- a/projectiles/NTacticalMissile2/NTacticalMissile2_Script.lua
+++ b/projectiles/NTacticalMissile2/NTacticalMissile2_Script.lua
@@ -2,33 +2,34 @@ local NIFCruiseMissile = import('/lua/nomadsprojectiles.lua').NIFCruiseMissile
 local RandomOffsetTrackingTarget = import('/lua/utilities.lua').RandomOffsetTrackingTarget
 
 NTacticalMissile2 = Class(NIFCruiseMissile) {
-	
-	OnCreate = function(self, inWater)
+    
+    OnCreate = function(self, inWater)
+        local pos = self:GetPosition()
         NIFCruiseMissile.OnCreate(self, inWater)
+        self.TargetPos = RandomOffsetTrackingTarget(self, 10)
         self:SetCollisionShape('Sphere', 0, 0, 0, 3.0) --these travel at a high speed so cybran which uses beams can miss!
         self:SetTurnRate(0)
+        self:SetNewTargetGround({pos[1],pos[2] + 70,pos[3]})
         self:ForkThread(self.StageThread)
     end,
 
     StageThread = function(self)
         WaitSeconds(1 +Random(0,100)*0.01)
         self:SetTurnRate(self:GetBlueprint().Physics.TurnRate)
-		
-        self:SetNewTargetGround(RandomOffsetTrackingTarget(self, 10))
+        WaitSeconds(2)
+        self:SetNewTargetGround({self.TargetPos[1],self.TargetPos[2],self.TargetPos[3]})
+        self:SetTurnRateByDist()
     end,
     
     SetTurnRateByDist = function(self)
         local dist = self:GetDistanceToTarget()
-        if dist > 50 then
+        if dist > 150 then
+            self:SetTurnRate(25)
+        elseif dist > 100 and dist <= 150 then
             self:SetTurnRate(50)
-        elseif dist > 40 and dist <= 213 then
-            self:SetTurnRate(40)
-            WaitSeconds(0.5)
-            self:SetTurnRate(60)
-        elseif dist > 20 and dist <= 40 then
-            WaitSeconds(0.3)
-            self:SetTurnRate(100)
-        elseif dist > 0 and dist <= 20 then
+        elseif dist > 50 and dist <= 100 then
+            self:SetTurnRate(75)
+        elseif dist > 0 and dist <= 50 then
             self:SetTurnRate(100)
             KillThread(self.MoveThread)
         end

--- a/units/XNL0403/XNL0403_unit.bp
+++ b/units/XNL0403/XNL0403_unit.bp
@@ -39,7 +39,7 @@ UnitBlueprint {
             Cue = 'Expl_Water_Lrg_01',
             LodCutoff = 'UnitMove_LodCutoff',
         },
-		NuclearLaunchDetected = Sound {
+        NuclearLaunchDetected = Sound {
             Bank = 'XGG',
             Cue = 'Computer_Computer_MissileLaunch_01351',
         },
@@ -382,7 +382,7 @@ UnitBlueprint {
     SelectionThickness = 0.3,
     SizeX = 5, -- keep 5 or higher to make sure the unit can move through structures
     SizeY = 1.8,
-    SizeZ = 10,	
+    SizeZ = 10,
     SpecialAbilities = {
         LaunchNuke = {
             AreaOfEffect = 40,
@@ -433,12 +433,12 @@ UnitBlueprint {
             MuzzleVelocity = 14.5,
             NotExclusive = true,
             ProjectileId = '/projectiles/NTacticalMissile2/NTacticalMissile2_proj.bp',
-            ProjectileLifetime = 13.5,
+            ProjectileLifetime = 18,
             ProjectilesPerOnFire = 1,
             RackBones = {
                 {
                     MuzzleBones = {
-					    'rocket_left',
+                        'rocket_left',
                         'rocket_left.001',
                         'rocket_left.002',
                         'rocket_left.003',
@@ -752,7 +752,7 @@ UnitBlueprint {
             Turreted = false,
             WeaponCategory = 'Anti Air',
         },
-		{
+        {
             AboveWaterTargetsOnly = true,
             Audio = {
                 Fire = Sound {


### PR DESCRIPTION
Crawler missiles fly vertically first to get height regardless of target direction and become more consistent on getting a hit on target at different heights