### PR TITLE
Reduce intel boost cost and utility

### DIFF
--- a/units/XNB3101/XNB3101_unit.bp
+++ b/units/XNB3101/XNB3101_unit.bp
@@ -163,7 +163,7 @@ UnitBlueprint {
             'xnb3201',
         },
         MaintenanceConsumptionPerSecondEnergy = 20,
-        MaintenanceConsumptionPerSecondEnergyBoosted = 5,
+        MaintenanceConsumptionPerSecondEnergyBoosted = 60,
         RebuildBonusIds = {
             'xnb3101',
         },
@@ -214,7 +214,7 @@ UnitBlueprint {
     },
     Intel = {
         RadarRadius = 115,
-        RadarRadiusBoosted = 80,
+        RadarRadiusBoosted = 145,
         ShowIntelOnSelect = true,
         VisionRadius = 20,
     },

--- a/units/XNB3102/XNB3102_unit.bp
+++ b/units/XNB3102/XNB3102_unit.bp
@@ -110,8 +110,8 @@ UnitBlueprint {
         BuildableCategory = {
             'xnb3202',
         },
-        MaintenanceConsumptionPerSecondEnergy = 20,
-        MaintenanceConsumptionPerSecondEnergyBoosted = 5,
+        MaintenanceConsumptionPerSecondEnergy = 10,
+        MaintenanceConsumptionPerSecondEnergyBoosted = 30,
         RebuildBonusIds = {
             'xnb3102',
         },
@@ -162,7 +162,7 @@ UnitBlueprint {
     Intel = {
         ShowIntelOnSelect = true,
         SonarRadius = 115,
-        SonarRadiusBoosted = 80,
+        SonarRadiusBoosted = 145,
         VisionRadius = 20,
     },
     Interface = {

--- a/units/XNB3201/XNB3201_unit.bp
+++ b/units/XNB3201/XNB3201_unit.bp
@@ -149,7 +149,7 @@ UnitBlueprint {
             'xnb3301',
         },
         MaintenanceConsumptionPerSecondEnergy = 150,
-        MaintenanceConsumptionPerSecondEnergyBoosted = 600,
+        MaintenanceConsumptionPerSecondEnergyBoosted = 450,
         RebuildBonusIds = {
             'xnb3201',
         },
@@ -201,7 +201,7 @@ UnitBlueprint {
     },
     Intel = {
         RadarRadius = 200,
-        RadarRadiusBoosted = 300,
+        RadarRadiusBoosted = 250,
         ShowIntelOnSelect = true,
         VisionRadius = 25,
     },

--- a/units/XNB3202/XNB3202_unit.bp
+++ b/units/XNB3202/XNB3202_unit.bp
@@ -112,7 +112,7 @@ UnitBlueprint {
             'xnb3302',
         },
         MaintenanceConsumptionPerSecondEnergy = 100,
-        MaintenanceConsumptionPerSecondEnergyBoosted = 400,
+        MaintenanceConsumptionPerSecondEnergyBoosted = 300,
         RebuildBonusIds = {
             'xnb3202',
         },
@@ -164,7 +164,7 @@ UnitBlueprint {
     Intel = {
         ShowIntelOnSelect = true,
         SonarRadius = 230,
-        SonarRadiusBoosted = 345,
+        SonarRadiusBoosted = 285,
         VisionRadius = 25,
     },
     Interface = {

--- a/units/XNB3301/XNB3301_unit.bp
+++ b/units/XNB3301/XNB3301_unit.bp
@@ -137,7 +137,7 @@ UnitBlueprint {
         BuildCostMass = 2400,
         BuildTime = 2575,
         MaintenanceConsumptionPerSecondEnergy = 2000,
-        MaintenanceConsumptionPerSecondEnergyBoosted = 8000,
+        MaintenanceConsumptionPerSecondEnergyBoosted = 6000,
         RebuildBonusIds = {
             'xnb3301',
         },
@@ -188,9 +188,9 @@ UnitBlueprint {
     },
     Intel = {
         OmniRadius = 200,
-        OmniRadiusBoosted = 300,
+        OmniRadiusBoosted = 250,
         RadarRadius = 600,
-        RadarRadiusBoosted = 900,
+        RadarRadiusBoosted = 750,
         ShowIntelOnSelect = true,
         VisionRadius = 30,
     },

--- a/units/XNB3302/XNB3302_unit.bp
+++ b/units/XNB3302/XNB3302_unit.bp
@@ -141,7 +141,7 @@ UnitBlueprint {
         BuildCostMass = 1000,
         BuildTime = 750,
         MaintenanceConsumptionPerSecondEnergy = 500,
-        MaintenanceConsumptionPerSecondEnergyBoosted = 2000,
+        MaintenanceConsumptionPerSecondEnergyBoosted = 1500,
         RebuildBonusIds = {
             'xnb3302',
         },
@@ -193,7 +193,7 @@ UnitBlueprint {
     Intel = {
         ShowIntelOnSelect = true,
         SonarRadius = 450,
-        SonarRadiusBoosted = 600,
+        SonarRadiusBoosted = 560,
         VisionRadius = 36,
         WaterVisionRadius = 36,
     },


### PR DESCRIPTION
Intel boost now gives +25% intel bonus instead of +50%
Energy drain is reduced to x3 from x4.
Power save mode is replaced by proper intel boost for t1 structures.
Basic Sonar drain is now same as other factions.