### PR TITLE
Prevent Crawler TML fly pass TMD

### DIFF
--- a/projectiles/NTacticalMissile2/NTacticalMissile2_Script.lua
+++ b/projectiles/NTacticalMissile2/NTacticalMissile2_Script.lua
@@ -15,17 +15,13 @@ NTacticalMissile2 = Class(NIFCruiseMissile) {
 
     StageThread = function(self)
         WaitSeconds(1 +Random(0,100)*0.01)
-        self:SetTurnRate(self:GetBlueprint().Physics.TurnRate)
-        WaitSeconds(2)
         self:SetNewTargetGround({self.TargetPos[1],self.TargetPos[2],self.TargetPos[3]})
         self:SetTurnRateByDist()
     end,
     
     SetTurnRateByDist = function(self)
         local dist = self:GetDistanceToTarget()
-        if dist > 150 then
-            self:SetTurnRate(25)
-        elseif dist > 100 and dist <= 150 then
+        if dist > 100 then
             self:SetTurnRate(50)
         elseif dist > 50 and dist <= 100 then
             self:SetTurnRate(75)


### PR DESCRIPTION
Missiles were launched too high, so TMD wouldn't reach them if target was way after TMD