### PR TITLE
Nerf Vangard torpedoes

### DIFF
--- a/units/XNA0203/XNA0203_unit.bp
+++ b/units/XNA0203/XNA0203_unit.bp
@@ -286,7 +286,7 @@ UnitBlueprint {
             BallisticArc = 'RULEUBA_None',
             CollideFriendly = false,
             Damage = 40,
-            DamageWater = 80,
+            DamageWater = 40,
             DamageRadius = 0.3,
             DamageRadiusWater = 0,
             DamageType = 'Normal',


### PR DESCRIPTION
Nerf Vangard torpedoes since they weren't supposed to be this strong.

Keep the code as it may be needed in future.