### PR TITLE
Fix for SACU presets category in blueprint.lua

### DIFF
--- a/nomadhook/lua/system/Blueprints.lua
+++ b/nomadhook/lua/system/Blueprints.lua
@@ -209,6 +209,7 @@ function HandleUnitWithBuildPresets(bps, all_bps)
             tempBp.Interface.HelpText = preset.HelpText or tempBp.Interface.HelpText
             tempBp.Description = preset.Description or tempBp.Description
             tempBp.CategoriesHash['ISPREENHANCEDUNIT'] = true
+            tempBp.CategoriesHash[string.upper(name..'PRESET')] = true
             -- clean up some data that's not needed anymore
             tempBp.CategoriesHash['USEBUILDPRESETS'] = false
             tempBp.EnhancementPresets = nil


### PR DESCRIPTION
The nomads hook in blueprint.lua (HandleUnitWithBuildPresets) is destructive and not up to date.
To handle SACU presets for the AI we added a category with presetname to a SACU
This way we can select a specific SACU with the AI platoonformer.

Also if people report that custom AIs are not working with nomads, its because of this error.
(Platoon builder will fail with an error because its calling a NIL when asking for categories.RAMBO as example.)