### PR TITLE
3725:Transports

### DIFF
--- a/units/XNA0104/XNA0104_Script.lua
+++ b/units/XNA0104/XNA0104_Script.lua
@@ -3,10 +3,15 @@
 local NomadsEffectTemplate = import('/lua/nomadseffecttemplate.lua')
 local AddLights = import('/lua/nomadsutils.lua').AddLights
 local NAirTransportUnit = import('/lua/nomadsunits.lua').NAirTransportUnit
+local DummyWeapon = import('/lua/aeonweapons.lua').AAASonicPulseBatteryWeapon
 
 NAirTransportUnit = AddLights( NAirTransportUnit )
 
 XNA0104 = Class(NAirTransportUnit) {
+    Weapons = {
+        GuidanceSystem = Class(DummyWeapon) {},
+    },
+
     DestructionTicks = 250,
 
     -- bones that can be hidden: Antenna01, Antenna02, Flare01, Flare02, Flare03, Flare04, Flare05, Flare06, RocketLauncherArm

--- a/units/XNA0104/XNA0104_unit.bp
+++ b/units/XNA0104/XNA0104_unit.bp
@@ -159,7 +159,7 @@ UnitBlueprint {
         Category = 'Transport',
         Classification = 'RULEUC_MilitaryAircraft',
         CommandCaps = {
-            RULEUCC_Attack = false,
+            RULEUCC_Attack = true,
             RULEUCC_Capture = false,
             RULEUCC_Ferry = true,
             RULEUCC_Guard = true,
@@ -232,6 +232,35 @@ UnitBlueprint {
         Level5 = 15,
     },
     Weapon = {
+        {
+            Damage = 0,
+            DisplayName = 'Weapon Guidance System',
+            FireTargetLayerCapsTable = {
+                Air = 'Land|Water|Seabed',
+                Land = 'Land|Water|Seabed',
+            },
+            Label = 'GuidanceSystem',
+            MaxRadius = 18,
+            MuzzleSalvoDelay = 1,
+            MuzzleSalvoSize = 0,
+            ProjectileId = '/projectiles/AAASonicPulse02/AAASonicPulse02_proj.bp',
+            RackBones = {
+                {
+                    MuzzleBones = {
+                        'Muzzle_R',
+                    },
+                    RackBone = 'Turret_Right',
+                },
+            },
+            RackRecoilDistance = 0,
+            TargetRestrictDisallow = 'UNTARGETABLE AIR',
+            TurretPitch = 0,
+            TurretPitchRange = 45,
+            TurretPitchSpeed = 360,
+            TurretYaw = 0,
+            TurretYawRange = 180,
+            TurretYawSpeed = 360,
+        },
        {
             AboveWaterTargetsOnly = true,
             Damage = 25,

--- a/units/XNA0107/XNA0107_script.lua
+++ b/units/XNA0107/XNA0107_script.lua
@@ -1,8 +1,13 @@
 -- T1 transport
 
 local NAirTransportUnit = import('/lua/nomadsunits.lua').NAirTransportUnit
+local DummyWeapon = import('/lua/aeonweapons.lua').AAASonicPulseBatteryWeapon
 
 XNA0107 = Class(NAirTransportUnit) {
+
+    Weapons = {
+        GuidanceSystem = Class(DummyWeapon) {},
+    },
 
     DestructionPartsLowToss = {0},
     DestroySeconds = 7.5,

--- a/units/XNA0107/XNA0107_unit.bp
+++ b/units/XNA0107/XNA0107_unit.bp
@@ -203,7 +203,7 @@ UnitBlueprint {
         Category = 'Transport',
         Classification = 'RULEUC_MilitaryAircraft',
         CommandCaps = {
-            RULEUCC_Attack = false,
+            RULEUCC_Attack = true,
             RULEUCC_CallTransport = true,
             RULEUCC_Capture = false,
             RULEUCC_Ferry = true,
@@ -270,6 +270,35 @@ UnitBlueprint {
     },
     UseOOBTestZoom = 200,
     Weapon = {
+        {
+            Damage = 0,
+            DisplayName = 'Weapon Guidance System',
+            FireTargetLayerCapsTable = {
+                Air = 'Land|Water|Seabed',
+                Land = 'Land|Water|Seabed',
+            },
+            Label = 'GuidanceSystem',
+            MaxRadius = 18,
+            MuzzleSalvoDelay = 1,
+            MuzzleSalvoSize = 0,
+            ProjectileId = '/projectiles/AAASonicPulse02/AAASonicPulse02_proj.bp',
+            RackBones = {
+                {
+                    MuzzleBones = {
+                        'Muzzle_R',
+                    },
+                    RackBone = 'Turret_Right',
+                },
+            },
+            RackRecoilDistance = 0,
+            TargetRestrictDisallow = 'UNTARGETABLE AIR',
+            TurretPitch = 0,
+            TurretPitchRange = 45,
+            TurretPitchSpeed = 360,
+            TurretYaw = 0,
+            TurretYawRange = 180,
+            TurretYawSpeed = 360,
+        },
         {
             AboveWaterTargetsOnly = true,
             Damage = 100,


### PR DESCRIPTION
Add dummyweapon to t1 and t2 transports in order to make getto gunships controlable.
Range is set 18 to match LAB range.