### PR TITLE
3761: Fix unit collision

### DIFF
--- a/units/XNA0001/XNA0001_unit.bp
+++ b/units/XNA0001/XNA0001_unit.bp
@@ -123,8 +123,8 @@ UnitBlueprint {
         TurnRate = 180,
     },
     SelectionThickness = 0.2,
-    SizeX = 0.25,
-    SizeY = 0.25,
-    SizeZ = 0.25,
+    SizeX = 2.05,
+    SizeY = 2.05,
+    SizeZ = 2.05,
     StrategicIconSortPriority = 105,
 }

--- a/units/XNA0302/XNA0302_unit.bp
+++ b/units/XNA0302/XNA0302_unit.bp
@@ -249,7 +249,7 @@ UnitBlueprint {
     SelectionSizeX = 0.75,
     SelectionSizeZ = 1,
     SelectionThickness = 0.5,
-    SizeSphere = 1.6,
+    SizeSphere = 2.71,
     SizeX = 1.1,
     SizeY = 0.25,
     SizeZ = 1.6,

--- a/units/XNA0303/XNA0303_unit.bp
+++ b/units/XNA0303/XNA0303_unit.bp
@@ -262,7 +262,7 @@ UnitBlueprint {
     SelectionSizeX = 1,
     SelectionSizeZ = 1.35,
     SelectionThickness = 0.35,
-    SizeSphere = 2,
+    SizeSphere = 2.21,
     SizeX = 1.45,
     SizeY = 0.35,
     SizeZ = 1.85,

--- a/units/XNC0003/XNC0003_unit.bp
+++ b/units/XNC0003/XNC0003_unit.bp
@@ -159,7 +159,7 @@ UnitBlueprint {
     SelectionSizeZ = 0.85,
     SelectionThickness = 0.38,
     SizeX = 0.45,
-    SizeY = 0.4,
+    SizeY = 0.5,
     SizeZ = 1.1,
     StrategicIconName = 'icon_land_generic',
     StrategicIconSortPriority = 207,

--- a/units/XNC2302/XNC2302_unit.bp
+++ b/units/XNC2302/XNC2302_unit.bp
@@ -142,7 +142,7 @@ UnitBlueprint {
     SelectionSizeZ = 0.65,
     SelectionThickness = 0.66,
     SizeX = 0.65,
-    SizeY = 0.4,
+    SizeY = 0.5,
     SizeZ = 0.9,
     StrategicIconName = 'icon_structure3_artillery',
     StrategicIconSortPriority = 175,

--- a/units/XNL0101/XNL0101_unit.bp
+++ b/units/XNL0101/XNL0101_unit.bp
@@ -254,7 +254,7 @@ UnitBlueprint {
     SelectionSizeZ = 0.55,
     SelectionThickness = 0.7,
     SizeX = 0.5,
-    SizeY = 0.2,
+    SizeY = 0.5,
     SizeZ = 0.8,
     StrategicIconName = 'icon_land1_intel',
     StrategicIconSortPriority = 135,

--- a/units/XNL0103/XNL0103_unit.bp
+++ b/units/XNL0103/XNL0103_unit.bp
@@ -209,7 +209,7 @@ UnitBlueprint {
     SelectionSizeZ = 0.55,
     SelectionThickness = 0.65,
     SizeX = 0.5,
-    SizeY = 0.4,
+    SizeY = 0.5,
     SizeZ = 0.85,
     StrategicIconName = 'icon_land1_aa_arty',
     StrategicIconSortPriority = 135,

--- a/units/XNL0105/XNL0105_unit.bp
+++ b/units/XNL0105/XNL0105_unit.bp
@@ -315,7 +315,7 @@ UnitBlueprint {
     SelectionSizeZ = 0.35,
     SelectionThickness = 0.95,
     SizeX = 0.7,
-    SizeY = 0.4,
+    SizeY = 0.5,
     SizeZ = 0.55,
     StrategicIconName = 'icon_land1_engineer',
     StrategicIconSortPriority = 105,

--- a/units/XNL0106/XNL0106_unit.bp
+++ b/units/XNL0106/XNL0106_unit.bp
@@ -264,7 +264,7 @@ UnitBlueprint {
     SelectionSizeZ = 0.45,
     SelectionThickness = 0.5,
     SizeX = 0.5,   
-    SizeY = 0.4,
+    SizeY = 0.5,
     SizeZ = 0.8,
     StrategicIconName = 'icon_bot1_directfire',
     StrategicIconSortPriority = 135,

--- a/units/XNL0107/XNL0107_unit.bp
+++ b/units/XNL0107/XNL0107_unit.bp
@@ -179,7 +179,7 @@ UnitBlueprint {
     SelectionSizeZ = 0.75,
     SelectionThickness = 0.6,
     SizeX = 0.7,
-    SizeY = 0.3,
+    SizeY = 0.5,
     SizeZ = 1.3,
     StrategicIconName = 'icon_land1_sniper',
     StrategicIconSortPriority = 135,

--- a/units/XNL0201/XNL0201_unit.bp
+++ b/units/XNL0201/XNL0201_unit.bp
@@ -187,7 +187,7 @@ UnitBlueprint {
     SelectionSizeZ = 0.6,
     SelectionThickness = 0.5,
     SizeX = 0.65, 
-    SizeY = 0.45,
+    SizeY = 0.5,
     SizeZ = 1.2,
     StrategicIconName = 'icon_land1_directfire',
     StrategicIconSortPriority = 135,

--- a/units/XNL0203/XNL0203_unit.bp
+++ b/units/XNL0203/XNL0203_unit.bp
@@ -255,7 +255,7 @@ UnitBlueprint {
     SelectionSizeZ = 0.9,
     SelectionThickness = 0.5,
     SizeX = 0.8,
-    SizeY = 0.4,
+    SizeY = 0.5,
     SizeZ = 1.35,
     StrategicIconName = 'icon_land2_directfire',
     StrategicIconSortPriority = 125,

--- a/units/XNL0205/XNL0205_unit.bp
+++ b/units/XNL0205/XNL0205_unit.bp
@@ -183,7 +183,7 @@ UnitBlueprint {
     SelectionSizeZ = 0.9,
     SelectionThickness = 0.66,
     SizeX = 0.75,
-    SizeY = 0.4,
+    SizeY = 0.5,
     SizeZ = 1.4,
     StrategicIconName = 'icon_land2_antiair',
     StrategicIconSortPriority = 125,

--- a/units/XNL0209/XNL0209_unit.bp
+++ b/units/XNL0209/XNL0209_unit.bp
@@ -329,7 +329,7 @@ UnitBlueprint {
     SelectionSizeZ = 0.8,
     SelectionThickness = 0.56,
     SizeX = 0.9,
-    SizeY = 0.3,
+    SizeY = 0.5,
     SizeZ = 0.9,
     StrategicIconName = 'icon_land2_antimissile',
     StrategicIconSortPriority = 200,

--- a/units/XNO0001/XNO0001_unit.bp
+++ b/units/XNO0001/XNO0001_unit.bp
@@ -144,9 +144,9 @@ UnitBlueprint {
     SelectionSizeX = 0.45,
     SelectionSizeZ = 0.65,
     SelectionThickness = 0.66,
-    SizeX = 0.65,
-    SizeY = 0.4,
-    SizeZ = 0.9,
+    SizeX = 3,
+    SizeY = 3,
+    SizeZ = 3,
     SpecialAbilities = {
     },
 --    StrategicIconName = 'icon_experimental_generic',

--- a/units/XNO2302/XNO2302_unit.bp
+++ b/units/XNO2302/XNO2302_unit.bp
@@ -159,9 +159,9 @@ UnitBlueprint {
     SelectionSizeX = 0.45,
     SelectionSizeZ = 0.65,
     SelectionThickness = 0.66,
-    SizeX = 0.65,
-    SizeY = 0.4,
-    SizeZ = 0.9,
+    SizeX = 1,
+    SizeY = 1,
+    SizeZ = 1,
     Veteran = {
         Level1 = 30,
         Level2 = 60,

--- a/units/XNS0203/XNS0203_unit.bp
+++ b/units/XNS0203/XNS0203_unit.bp
@@ -291,7 +291,7 @@ UnitBlueprint {
     SelectionSizeX = 0.3,
     SelectionSizeZ = 1.5,
     SelectionThickness = 0.25,
-    SizeX = 0.55,
+    SizeX = 0.61,
     SizeY = 0.5,
     SizeZ = 2.4,
     StrategicIconName = 'icon_sub1_antinavy',


### PR DESCRIPTION
FAF has a code that auto-adjusts these sizes anyway. This is misc change in order to remove game log spam.