### PR TITLE
Fixed XNA0401 (Atlas) bugs

### DIFF
--- a/units/XNA0401/XNA0401_script.lua
+++ b/units/XNA0401/XNA0401_script.lua
@@ -44,7 +44,14 @@ XNA0401 = Class(NExperimentalAirTransportUnit) {
         EngineRotatorLeft03 = true,
         EngineRotatorLeft04 = true
     },
-
+	
+ ---@param self AirTransport
+    ---@param totalweight CargoWeight
+    ---@param unit Unit
+    ReduceTransportSpeed = function(self)
+		--no speed reduction from picking up units
+    end,
+	
     ---@param self XNA0401
     ---@param builder Unit
     ---@param layer Layer

--- a/units/XNA0401/XNA0401_script.lua
+++ b/units/XNA0401/XNA0401_script.lua
@@ -45,9 +45,7 @@ XNA0401 = Class(NExperimentalAirTransportUnit) {
         EngineRotatorLeft04 = true
     },
 	
- ---@param self AirTransport
-    ---@param totalweight CargoWeight
-    ---@param unit Unit
+    ---@param self AirTransport
     ReduceTransportSpeed = function(self)
 		--no speed reduction from picking up units
     end,

--- a/units/XNA0401/XNA0401_unit.bp
+++ b/units/XNA0401/XNA0401_unit.bp
@@ -61,6 +61,7 @@ UnitBlueprint{
         "NEEDMOBILEBUILD",
         "NOMADS",
         "OVERLAYANTIAIR",
+        "CANLANDONWATER",
         "SELECTABLE",
         "SNIPEMODE",
         "TRANSPORTATION",


### PR DESCRIPTION
##what
This fixes game breaking bugs related to the Atlas experimental unit
Currently, the unit cannot pick up naval units the way its description suggests, and there are extraordinary issues that result from loading the transport to capacity. Including events like flying off the map and moving at insane airspeeds.

##why
Without these changes it's possible to crash the game by flying the unit out of bounds and then self destructing. Also, the unit itself flips over and gets stuck often.

##how
The fix is to simply remove the airspeed reduction that occurs from attaching new units. The airspeed reduction can reduce airspeed below zero causing unanticipated consequences. 
picking up naval units is impossible because the transport can't land on water to lift them. Adding a "CanLandOnWater" tag to the bp file fixes that.

Issues:
https://github.com/FAForever/nomads/issues/683#issue-2520953091
