### PR TITLE
Fix xns0102 and xns0205 localization tags

### DIFF
--- a/loc/US/nomads_strings_core.lua
+++ b/loc/US/nomads_strings_core.lua
@@ -354,9 +354,9 @@ xns0103_help = "Low-end naval unit. Armed with a singular fast firing cannon and
 xns0103_name = "Lance Class"
 
 -- artillery boat
-XNS0102_desc = "Artillery Boat"
-XNS0102_help = "Low-end naval unit. Armed with two anti-air missile launchers. Can also target surface units with its rockets."
-XNS0102_name = "Defender Class"
+xns0102_desc = "Artillery Boat"
+xns0102_help = "Low-end naval unit. Armed with two anti-air missile launchers. Can also target surface units with its rockets."
+xns0102_name = "Defender Class"
 
 
 -- Structures

--- a/nomadhook/lua/ui/help/unitdescription.lua
+++ b/nomadhook/lua/ui/help/unitdescription.lua
@@ -193,11 +193,12 @@ Description = table.merged( Description, {
 
     -- NOMADS SEA UNITS
     ['xns0203'] = "<LOC xns0203_help>Attack Submarine",
+    ['xns0102'] = "<LOC xns0102_help>Artillery Boat",
     ['xns0103'] = "<LOC xns0103_help>Frigate",
 
     ['xns0201'] = "<LOC xns0201_help>Destroyer",
     ['xns0202'] = "<LOC xns0202_help>Cruiser",
-    ['xns0102'] = "<LOC xns0102_help>Torpedo Boat",
+    ['xns0205'] = "<LOC xns0205_help>EMP Ship",
 
     ['xns0301'] = "<LOC xns0301_help>Battleship",
     ['xns0304'] = "<LOC xns0304_help>Heavy Attack Submarine",

--- a/units/XNS0102/XNS0102_unit.bp
+++ b/units/XNS0102/XNS0102_unit.bp
@@ -1,5 +1,5 @@
 UnitBlueprint{
-    Description = "<LOC XNS0102_desc>Artillery Boat",
+    Description = "<LOC xns0102_desc>Artillery Boat",
     Audio = {
         AmbientMove = Sound { Bank = 'UES',             Cue = 'UES0103_Move_Loop',   LodCutoff = 'UnitMove_LodCutoff' },
         Killed      = Sound { Bank = 'UESDestroy',      Cue = 'UES0103_Destroy',     LodCutoff = 'UnitMove_LodCutoff' },
@@ -126,11 +126,11 @@ UnitBlueprint{
         FactionName = "Nomads",
         Icon = "sea",
         TechLevel = "RULEUTL_Basic",
-        UnitName = "<LOC XNS0102_name>Defender Class",
+        UnitName = "<LOC xns0102_name>Defender Class",
         UnitWeight = 1,
     },
     Intel = { VisionRadius = 32 },
-    Interface = { HelpText = "<LOC XNS0102_help>Artillery Boat" },
+    Interface = { HelpText = "<LOC xns0102_help>Artillery Boat" },
     LifeBarHeight = 0.075,
     LifeBarOffset = 1.7,
     LifeBarSize = 1.25,

--- a/units/XNS0205/XNS0205_unit.bp
+++ b/units/XNS0205/XNS0205_unit.bp
@@ -1,5 +1,5 @@
 UnitBlueprint{
-    Description = "<LOC XNS0205_desc>Anti-Submersible Boat",
+    Description = "<LOC xns0205_desc>Anti-Submersible Boat",
     AI = { AttackAngle = 30 },
     Audio = {
         AmbientMove = Sound { Bank = 'XES',             Cue = 'XES0102_Move_Loop',   LodCutoff = 'UnitMove_LodCutoff' },
@@ -129,7 +129,7 @@ UnitBlueprint{
         FactionName = "Nomads",
         Icon = "sea",
         TechLevel = "RULEUTL_Advanced",
-        UnitName = "<LOC XNS0205_name>Whaler",
+        UnitName = "<LOC xns0205_name>Whaler",
         UnitWeight = 1,
     },
     Intel = {
@@ -137,7 +137,7 @@ UnitBlueprint{
         VisionRadius = 32,
         WaterVisionRadius = 55,
     },
-    Interface = { HelpText = "<LOC XNS0205_help>Uses two railguns under water to attack ships and submarines. Also carries a tactical missile defense turret." },
+    Interface = { HelpText = "<LOC xns0205_help>Uses two railguns under water to attack ships and submarines. Also carries a tactical missile defense turret." },
     LifeBarHeight = 0.075,
     LifeBarOffset = 2.45,
     LifeBarSize = 1.75,


### PR DESCRIPTION
## Issue
`xns0102` had uppercase for its LOC tags (which is inconsistent with all other tags), but it was lowercase in the unit description file, so the UI wouldn't show any description for it.
`xns0205` had uppercase for tag but lowercase in the actual tags file, so the UI wouldn't show any description for it.
![{50604736-EE45-49E4-9C51-571867988925}](https://github.com/user-attachments/assets/2ffc9f13-7554-4251-b3ec-bc2eed1a3f8e)![{A01EB8FF-D955-4425-B5B9-80D04C424819}](https://github.com/user-attachments/assets/192a8c61-132e-40e3-8a75-4b8f2775a5a5)

## Testing
Both units now show descriptions and have the correct names.
![{F7942199-CD92-4F33-A41F-65953855C8E3}](https://github.com/user-attachments/assets/c534abb8-a03e-45ce-977b-60309ad8757d)![{DE01AF50-6B29-4FE8-8850-9739878197F6}](https://github.com/user-attachments/assets/944177dc-b645-4b12-b1c5-497b2633e1e8)
